### PR TITLE
Document netstorage upload and change plugin location to rh-che/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,29 @@ Then pass in the build arguments:
 ## Running Tests
 
 `mvn verify`
+
+
+## Publishing a new version of the plugin `meta.yaml` file
+
+The plugin `meta.yaml` is hosted on a CDN at [static.developers.redhat.com](https://static.developers.redhat.com).  In order to push a new version, you will need the appropriate Akamai credential file, with the following layout:
+
+```
+[default]
+key = key = <Secret key for the Akamai NetStorage account>
+id = <NetStorage account ID>
+group = <NetStorage storage group>
+host = <NetStorage host>
+cpcode = <NetStorage CPCode>
+```
+
+Save this file as `akamai-auth.conf`.
+
+In the root of this repository, run:
+
+```shell
+docker run -w /root/app -v $(pwd):/root/app -v \
+  /path/to/akamai-auth.conf:/root/.akamai-cli/.netstorage/auth \
+  akamai/cli netstorage upload \
+  --directory rh-che/plugins/che-workspace-telemetry-woopra-backend/0.0.1 \
+  meta.yaml
+```

--- a/meta.yaml
+++ b/meta.yaml
@@ -4,6 +4,7 @@ name: che-workspace-telemetry-woopra-backend
 version: 0.0.1
 type: Che Plugin
 displayName: Woopra Telemetry Backend
+description: Telemetry plugin to send information to Woopra
 title: Che Workspace Telemetry Woopra Backend
 category: Other
 spec:
@@ -12,7 +13,7 @@ spec:
       value: '4167'
   containers:
   - name: che-workspace-telemetry-woopra-backend
-    image: quay.io/tgeorge/che-workspace-telemetry-woopra-backend:dev
+    image: quay.io/openshiftio/che-workspace-telemetry-woopra-backend:latest
     env:
       - name: CHE_API
         value: $(CHE_API_INTERNAL)


### PR DESCRIPTION
- Set quay.io URL for plugin image 
- Document how to upload a plugin to the CDN.  
- Docs refer to a new location for the plugin instead of `che/theia_artifacts`, how do you feel about `rh-che/plugins`