### PR TITLE
Telemetry refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
       <artifactId>backend-base</artifactId>
-      <version>0.0.11</version>
+      <version>0.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>

--- a/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
+++ b/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
@@ -93,7 +93,6 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         String endpoint = apiEndpoint + "/fabric8-che-analytics/segment-write-key";
         segmentWriteKey = requestFactory.fromUrl(endpoint).request().asString();
       }
-
       if (woopraDomain == null) {
         String endpoint = apiEndpoint + "/fabric8-che-analytics/woopra-domain";
         woopraDomain = requestFactory.fromUrl(endpoint).request().asString();
@@ -190,6 +189,9 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
     }
     ;
   }
+
+  @Override
+  public void increaseDuration(AnalyticsEvent event, Map<String, Object> properties) {}
 
   @VisibleForTesting
   class EventDispatcher {

--- a/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
+++ b/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
@@ -147,7 +147,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
       LOG.debug("Checking activity of dispatcher for user: {}", dispatcher.getUserId());
       if (dispatcher.getLastActivityTime() < inactiveLimit) {
         LOG.debug("Sending 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
-        if (dispatcher.sendTrackEvent(WORKSPACE_INACTIVE, getCommonProperties(), dispatcher.getLastIp(),
+        if (dispatcher.sendTrackEvent(WORKSPACE_INACTIVE, getCurrentEventProperties(), dispatcher.getLastIp(),
             dispatcher.getLastUserAgent(), dispatcher.getLastResolution()) != null) {
           LOG.debug("Sent 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
           return;
@@ -166,7 +166,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         long expectedDuration = lastEvent.getExpectedDurationSeconds() * 1000;
         if (lastEvent == WORKSPACE_INACTIVE || (expectedDuration >= 0
             && System.currentTimeMillis() > expectedDuration + dispatcher.getLastEventTime())) {
-          dispatcher.sendTrackEvent(WORKSPACE_USED, getCommonProperties(), dispatcher.getLastIp(),
+          dispatcher.sendTrackEvent(WORKSPACE_USED, getCurrentEventProperties(), dispatcher.getLastIp(),
               dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
         }
       }
@@ -380,14 +380,11 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
   }
 
   public void destroy() {
-    LOG.info("onDestroy startingUsedId " + getUserId());
     if (getUserId() != null) {
       EventDispatcher dispatcher;
       try {
-        LOG.info("sending WORKSPACE_STOPPED event");
         dispatcher = dispatchers.get(getUserId());
-
-        dispatcher.sendTrackEvent(WORKSPACE_STOPPED, commonProperties, dispatcher.getLastIp(), dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
+        dispatcher.sendTrackEvent(WORKSPACE_STOPPED, getCurrentEventProperties(), dispatcher.getLastIp(), dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
       } catch (ExecutionException e) {
       }
     }

--- a/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
+++ b/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
@@ -147,7 +147,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
       LOG.debug("Checking activity of dispatcher for user: {}", dispatcher.getUserId());
       if (dispatcher.getLastActivityTime() < inactiveLimit) {
         LOG.debug("Sending 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
-        if (dispatcher.sendTrackEvent(WORKSPACE_INACTIVE, getCurrentEventProperties(), dispatcher.getLastIp(),
+        if (dispatcher.sendTrackEvent(WORKSPACE_INACTIVE, commonProperties, dispatcher.getLastIp(),
             dispatcher.getLastUserAgent(), dispatcher.getLastResolution()) != null) {
           LOG.debug("Sent 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
           return;
@@ -166,7 +166,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         long expectedDuration = lastEvent.getExpectedDurationSeconds() * 1000;
         if (lastEvent == WORKSPACE_INACTIVE || (expectedDuration >= 0
             && System.currentTimeMillis() > expectedDuration + dispatcher.getLastEventTime())) {
-          dispatcher.sendTrackEvent(WORKSPACE_USED, getCurrentEventProperties(), dispatcher.getLastIp(),
+          dispatcher.sendTrackEvent(WORKSPACE_USED, commonProperties, dispatcher.getLastIp(),
               dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
         }
       }
@@ -384,7 +384,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
       EventDispatcher dispatcher;
       try {
         dispatcher = dispatchers.get(getUserId());
-        dispatcher.sendTrackEvent(WORKSPACE_STOPPED, getCurrentEventProperties(), dispatcher.getLastIp(), dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
+        dispatcher.sendTrackEvent(WORKSPACE_STOPPED, commonProperties, dispatcher.getLastIp(), dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
       } catch (ExecutionException e) {
       }
     }

--- a/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
+++ b/src/main/java/com/redhat/che/workspace/services/telemetry/woopra/AnalyticsManager.java
@@ -34,11 +34,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,10 +42,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -61,61 +53,41 @@ import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.eclipse.che.incubator.workspace.telemetry.base.AbstractAnalyticsManager;
 import org.eclipse.che.incubator.workspace.telemetry.base.AnalyticsEvent;
-import org.eclipse.che.incubator.workspace.telemetry.base.EventProperties;
 import com.segment.analytics.Analytics;
-import com.segment.analytics.Callback;
-import com.segment.analytics.messages.Message;
 import com.segment.analytics.messages.TrackMessage;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.slf4j.Logger;
 
 /**
- * Send event to Segment.com and regularly ping Woopra. For now the events are provided by the
- * {@link UrlToEventFilter}.
+ * Send event to Segment.com and regularly ping Woopra. For now the events are
+ * provided by the {@link UrlToEventFilter}.
  *
  * @author David Festal
  */
 public class AnalyticsManager extends AbstractAnalyticsManager {
   private static final Logger LOG = getLogger(AnalyticsManager.class);
 
-  private static final String pingRequestFormat =
-      "http://www.woopra.com/track/ping?host={0}&cookie={1}&timeout={2}&ka={3}&ra={4}";
+  private static final String pingRequestFormat = "http://www.woopra.com/track/ping?host={0}&cookie={1}&timeout={2}&ka={3}&ra={4}";
 
   private final Analytics analytics;
-
-  @VisibleForTesting static long pingTimeoutSeconds = 30;
-  @VisibleForTesting static long pingTimeout = pingTimeoutSeconds * 1000;
-
-  @VisibleForTesting long noActivityTimeout = 60000 * 3;
 
   String segmentWriteKey;
   String woopraDomain;
 
-  private ScheduledExecutorService checkActivityExecutor =
-      Executors.newSingleThreadScheduledExecutor(
-          new ThreadFactoryBuilder().setNameFormat("Analytics Activity Checker").build());
+  @VisibleForTesting
+  ScheduledExecutorService networkExecutor = Executors.newSingleThreadScheduledExecutor(
+      new ThreadFactoryBuilder().setNameFormat("Analytics Network Request Submitter").build());
 
   @VisibleForTesting
-  ScheduledExecutorService networkExecutor =
-      Executors.newSingleThreadScheduledExecutor(
-          new ThreadFactoryBuilder().setNameFormat("Analytics Network Request Submitter").build());
+  LoadingCache<String, EventDispatcher> dispatchers;
 
-  @VisibleForTesting LoadingCache<String, EventDispatcher> dispatchers;
+  @VisibleForTesting
+  HttpUrlConnectionProvider httpUrlConnectionProvider = null;
 
-  @VisibleForTesting String workspaceStartingUserId = null;
-  @VisibleForTesting HttpUrlConnectionProvider httpUrlConnectionProvider = null;
-
-  public AnalyticsManager(
-      String defaultSegmentWriteKey,
-      String defaultWoopraDomain,
-      String apiEndpoint,
-      String workspaceId,
-      String machineToken,
-      HttpJsonRequestFactory requestFactory,
-      AnalyticsProvider analyticsProvider,
-      HttpUrlConnectionProvider httpUrlConnectionProvider) {
+  public AnalyticsManager(String defaultSegmentWriteKey, String defaultWoopraDomain, String apiEndpoint,
+      String workspaceId, String machineToken, HttpJsonRequestFactory requestFactory,
+      AnalyticsProvider analyticsProvider, HttpUrlConnectionProvider httpUrlConnectionProvider) {
     super(apiEndpoint, workspaceId, machineToken, requestFactory);
     segmentWriteKey = defaultSegmentWriteKey;
     woopraDomain = defaultWoopraDomain;
@@ -140,31 +112,10 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
 
     if (isEnabled()) {
       this.httpUrlConnectionProvider = httpUrlConnectionProvider;
-
       analytics = analyticsProvider.getAnalytics(segmentWriteKey, networkExecutor);
     } else {
       analytics = null;
     }
-
-    long checkActivityPeriod = pingTimeoutSeconds / 2;
-
-    LOG.debug("CheckActivityPeriod: {}", checkActivityPeriod);
-
-    checkActivityExecutor.scheduleAtFixedRate(
-        this::checkActivity, checkActivityPeriod, checkActivityPeriod, SECONDS);
-
-    dispatchers =
-        CacheBuilder.newBuilder()
-            .expireAfterAccess(1, TimeUnit.HOURS)
-            .maximumSize(10)
-            .removalListener(
-                (RemovalNotification<String, EventDispatcher> n) -> {
-                  EventDispatcher dispatcher = n.getValue();
-                  if (dispatcher != null) {
-                    dispatcher.close();
-                  }
-                })
-            .build(CacheLoader.<String, EventDispatcher>from(userId -> newEventDispatcher(userId)));
   }
 
   private EventDispatcher newEventDispatcher(String userId) {
@@ -183,50 +134,34 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
   private void checkActivity() {
     LOG.debug("In checkActivity");
     long inactiveLimit = System.currentTimeMillis() - noActivityTimeout;
-    dispatchers
-        .asMap()
-        .values()
-        .forEach(
-            dispatcher -> {
-              LOG.debug("Checking activity of dispatcher for user: {}", dispatcher.getUserId());
-              if (dispatcher.getLastActivityTime() < inactiveLimit) {
-                LOG.debug(
-                    "Sending 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
-                if (dispatcher.sendTrackEvent(
-                        WORKSPACE_INACTIVE,
-                        Collections.emptyMap(),
-                        dispatcher.getLastIp(),
-                        dispatcher.getLastUserAgent(),
-                        dispatcher.getLastResolution())
-                    != null) {
-                  LOG.debug("Sent 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
-                  return;
-                }
-                LOG.debug(
-                    "Skipped sending 'WORKSPACE_INACTIVE' event for user: {} since it is the same event as the previous one",
-                    dispatcher.getUserId());
-                return;
-              }
-              synchronized (dispatcher) {
-                AnalyticsEvent lastEvent = dispatcher.getLastEvent();
-                if (lastEvent == null) {
-                  return;
-                }
+    dispatchers.asMap().values().forEach(dispatcher -> {
+      LOG.debug("Checking activity of dispatcher for user: {}", dispatcher.getUserId());
+      if (dispatcher.getLastActivityTime() < inactiveLimit) {
+        LOG.debug("Sending 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
+        if (dispatcher.sendTrackEvent(WORKSPACE_INACTIVE, getCommonProperties(), dispatcher.getLastIp(),
+            dispatcher.getLastUserAgent(), dispatcher.getLastResolution()) != null) {
+          LOG.debug("Sent 'WORKSPACE_INACTIVE' event for user: {}", dispatcher.getUserId());
+          return;
+        }
+        LOG.debug(
+            "Skipped sending 'WORKSPACE_INACTIVE' event for user: {} since it is the same event as the previous one",
+            dispatcher.getUserId());
+        return;
+      }
+      synchronized (dispatcher) {
+        AnalyticsEvent lastEvent = dispatcher.getLastEvent();
+        if (lastEvent == null) {
+          return;
+        }
 
-                long expectedDuration = lastEvent.getExpectedDurationSeconds() * 1000;
-                if (lastEvent == WORKSPACE_INACTIVE
-                    || (expectedDuration >= 0
-                        && System.currentTimeMillis()
-                            > expectedDuration + dispatcher.getLastEventTime())) {
-                  dispatcher.sendTrackEvent(
-                      WORKSPACE_USED,
-                      Collections.emptyMap(),
-                      dispatcher.getLastIp(),
-                      dispatcher.getLastUserAgent(),
-                      dispatcher.getLastResolution());
-                }
-              }
-            });
+        long expectedDuration = lastEvent.getExpectedDurationSeconds() * 1000;
+        if (lastEvent == WORKSPACE_INACTIVE || (expectedDuration >= 0
+            && System.currentTimeMillis() > expectedDuration + dispatcher.getLastEventTime())) {
+          dispatcher.sendTrackEvent(WORKSPACE_USED, getCommonProperties(), dispatcher.getLastIp(),
+              dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
+        }
+      }
+    });
   }
 
   public void onActivity() {
@@ -237,20 +172,8 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
     }
   }
 
-
-  public void onEvent(
-    AnalyticsEvent event,
-    String ownerId,
-    String ip,
-    String userAgent,
-    String resolution,
-    Map<String, Object> properties) {
-  if (event == WORKSPACE_OPENED && workspaceStartingUserId == null){
-    event = WORKSPACE_STARTED;
-  }
-  if (event == WORKSPACE_STARTED) {
-      workspaceStartingUserId = userId;
-    }
+  public void onEvent(AnalyticsEvent event, String ownerId, String ip, String userAgent, String resolution,
+      Map<String, Object> properties) {
     try {
       dispatchers.get(userId).sendTrackEvent(event, properties, ip, userAgent, resolution);
     } catch (ExecutionException e) {
@@ -262,11 +185,14 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
   @VisibleForTesting
   class EventDispatcher {
 
-    @VisibleForTesting String userId;
-    @VisibleForTesting String cookie;
+    @VisibleForTesting
+    String userId;
+    @VisibleForTesting
+    String cookie;
 
     private AnalyticsEvent lastEvent = null;
-    @VisibleForTesting Map<String, Object> lastEventProperties = null;
+    @VisibleForTesting
+    Map<String, Object> lastEventProperties = null;
     private long lastActivityTime;
     private long lastEventTime;
     private String lastIp = null;
@@ -274,78 +200,28 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
     private String lastResolution = null;
     private ScheduledFuture<?> pinger = null;
 
-    private Map<String, Object> commonProperties;
-
     EventDispatcher(String userId, AnalyticsManager manager) {
       this.userId = userId;
-      ImmutableMap.Builder<String, Object> commonPropertiesBuilder = builder();
-
-      commonPropertiesBuilder.put(WORKSPACE_ID, workspaceId);
-      commonPropertiesBuilder.put(WORKSPACE_NAME, workspaceName);
-
-      Arrays.asList(
-              new SimpleImmutableEntry<>(EventProperties.CREATED, createdOn),
-              new SimpleImmutableEntry<>(EventProperties.UPDATED, updatedOn),
-              new SimpleImmutableEntry<>(EventProperties.STOPPED, stoppedOn),
-              new SimpleImmutableEntry<>(EventProperties.AGE, age),
-              new SimpleImmutableEntry<>(EventProperties.RETURN_DELAY, returnDelay),
-              new SimpleImmutableEntry<>(EventProperties.FIRST_START, firstStart),
-              new SimpleImmutableEntry<>(EventProperties.STACK_ID, stackId),
-              new SimpleImmutableEntry<>(EventProperties.FACTORY_ID, factoryId),
-              new SimpleImmutableEntry<>(EventProperties.FACTORY_NAME, factoryName),
-              new SimpleImmutableEntry<>(EventProperties.FACTORY_URL, factoryUrl),
-              new SimpleImmutableEntry<>(EventProperties.FACTORY_OWNER, factoryOwner),
-              new SimpleImmutableEntry<>(EventProperties.LAST_WORKSPACE_FAILED, stoppedAbnormally),
-              new SimpleImmutableEntry<>(EventProperties.LAST_WORKSPACE_FAILURE, lastErrorMessage),
-              new SimpleImmutableEntry<>(EventProperties.OSIO_SPACE_ID, osioSpaceId),
-              new SimpleImmutableEntry<>(EventProperties.SOURCE_TYPES, sourceTypes),
-              new SimpleImmutableEntry<>(EventProperties.START_NUMBER, startNumber),
-              new SimpleImmutableEntry<>(EventProperties.PLUGINS, makePluginString(manager.pluginNames)))
-          .forEach(
-              (entry) -> {
-                if (entry.getValue() != null) {
-                  commonPropertiesBuilder.put(entry.getKey(), entry.getValue());
-                }
-              });
-
-      commonProperties = commonPropertiesBuilder.build();
-      cookie =
-          Hashing.md5()
-              .hashString(workspaceId + userId + System.currentTimeMillis(), StandardCharsets.UTF_8)
-              .toString();
-      LOG.info(
-          "Analytics Woopra Cookie for user {} and workspace {} : {}", userId, workspaceId, cookie);
+      cookie = Hashing.md5().hashString(workspaceId + userId + System.currentTimeMillis(), StandardCharsets.UTF_8)
+          .toString();
+      LOG.info("Analytics Woopra Cookie for user {} and workspace {} : {}", userId, workspaceId, cookie);
     }
 
     void onActivity() {
       lastActivityTime = System.currentTimeMillis();
     }
 
-    private String makePluginString(List<String> pluginNames) {
-      return pluginNames.stream().collect(Collectors.joining(", "));
-    }
-
     void sendPingRequest(boolean retrying) {
       boolean failed = false;
       try {
-        String uri =
-            MessageFormat.format(
-                pingRequestFormat,
-                URLEncoder.encode(woopraDomain, "UTF-8"),
-                URLEncoder.encode(cookie, "UTF-8"),
-                Long.toString(pingTimeout),
-                Long.toString(pingTimeout),
-                UUID.randomUUID().toString());
-        LOG.debug(
-            "Sending a PING request to woopra for user '{}' and cookie {} : {}",
-            getUserId(),
-            cookie,
-            uri);
+        String uri = MessageFormat.format(pingRequestFormat, URLEncoder.encode(woopraDomain, "UTF-8"),
+            URLEncoder.encode(cookie, "UTF-8"), Long.toString(pingTimeout), Long.toString(pingTimeout),
+            UUID.randomUUID().toString());
+        LOG.debug("Sending a PING request to woopra for user '{}' and cookie {} : {}", getUserId(), cookie, uri);
         HttpURLConnection httpURLConnection = httpUrlConnectionProvider.getHttpUrlConnection(uri);
 
         String responseMessage;
-        try (BufferedReader br =
-                new BufferedReader(new InputStreamReader(httpURLConnection.getInputStream()));
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(httpURLConnection.getInputStream()));
             StringWriter sw = new StringWriter()) {
           String inputLine;
 
@@ -354,11 +230,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
           }
           responseMessage = sw.toString();
         }
-        LOG.debug(
-            "Woopra PING response for user '{}' and cookie {} : {}",
-            userId,
-            cookie,
-            responseMessage);
+        LOG.debug("Woopra PING response for user '{}' and cookie {} : {}", userId, cookie, responseMessage);
         if (responseMessage == null) {
           failed = true;
         }
@@ -367,8 +239,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
           failed = true;
         }
         if (failed) {
-          LOG.warn(
-              "Cannot ping woopra for cookie {} - response message : {}", cookie, responseMessage);
+          LOG.warn("Cannot ping woopra for cookie {} - response message : {}", cookie, responseMessage);
         }
       } catch (Exception e) {
         LOG.warn("Cannot ping woopra", e);
@@ -404,18 +275,13 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
       return true;
     }
 
-    String sendTrackEvent(
-        AnalyticsEvent event, final Map<String, Object> properties, String ip, String userAgent, String resolution) {
+    String sendTrackEvent(AnalyticsEvent event, final Map<String, Object> properties, String ip, String userAgent,
+        String resolution) {
       return sendTrackEvent(event, properties, ip, userAgent, resolution, false);
     }
 
-    String sendTrackEvent(
-        AnalyticsEvent event,
-        final Map<String, Object> properties,
-        String ip,
-        String userAgent,
-        String resolution,
-        boolean force) {
+    String sendTrackEvent(AnalyticsEvent event, final Map<String, Object> properties, String ip, String userAgent,
+        String resolution, boolean force) {
       String eventId;
       lastIp = ip;
       lastUserAgent = userAgent;
@@ -429,21 +295,17 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         }
 
         eventId = UUID.randomUUID().toString();
-        TrackMessage.Builder messageBuilder =
-            TrackMessage.builder(event.toString()).userId(userId).messageId(eventId);
+        TrackMessage.Builder messageBuilder = TrackMessage.builder(event.toString()).userId(userId).messageId(eventId);
 
-        ImmutableMap.Builder<String, Object> integrationBuilder =
-            ImmutableMap.<String, Object>builder()
-                .put("cookie", cookie)
-                .put("timeout", pingTimeout);
+        ImmutableMap.Builder<String, Object> integrationBuilder = ImmutableMap.<String, Object>builder()
+            .put("cookie", cookie).put("timeout", pingTimeout);
         messageBuilder.integrationOptions("Woopra", integrationBuilder.build());
 
-        ImmutableMap.Builder<String, Object> propertiesBuilder =
-            ImmutableMap.<String, Object>builder().putAll(commonProperties).putAll(properties);
+        ImmutableMap.Builder<String, Object> propertiesBuilder = ImmutableMap.<String, Object>builder()
+            .putAll(properties);
         messageBuilder.properties(propertiesBuilder.build());
 
-        ImmutableMap.Builder<String, Object> contextBuilder =
-            ImmutableMap.<String, Object>builder().put("ip", ip);
+        ImmutableMap.Builder<String, Object> contextBuilder = ImmutableMap.<String, Object>builder().put("ip", ip);
         if (userAgent != null) {
           contextBuilder.put("userAgent", userAgent);
         }
@@ -452,15 +314,8 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         }
         messageBuilder.context(contextBuilder.build());
 
-        LOG.debug(
-            "sending "
-                + event.toString()
-                + " (ip="
-                + theIp
-                + " - userAgent="
-                + userAgent
-                + ") with properties: "
-                + properties);
+        LOG.debug("sending " + event.toString() + " (ip=" + theIp + " - userAgent=" + userAgent + ") with properties: "
+            + properties);
         analytics.enqueue(messageBuilder);
 
         lastEvent = event;
@@ -473,9 +328,8 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
         }
 
         LOG.debug("scheduling ping request with the following delay: " + pingPeriod);
-        pinger =
-            networkExecutor.scheduleAtFixedRate(
-                () -> sendPingRequest(false), pingPeriod, pingPeriod, TimeUnit.SECONDS);
+        pinger = networkExecutor.scheduleAtFixedRate(() -> sendPingRequest(false), pingPeriod, pingPeriod,
+            TimeUnit.SECONDS);
       }
       return eventId;
     }
@@ -517,16 +371,14 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
   }
 
   public void destroy() {
-    if (workspaceStartingUserId != null) {
+    LOG.info("onDestroy startingUsedId " + getUserId());
+    if (getUserId() != null) {
       EventDispatcher dispatcher;
       try {
-        dispatcher = dispatchers.get(workspaceStartingUserId);
-        dispatcher.sendTrackEvent(
-            WORKSPACE_STOPPED,
-            Collections.emptyMap(),
-            dispatcher.getLastIp(),
-            dispatcher.getLastUserAgent(),
-            dispatcher.getLastResolution());
+        LOG.info("sending WORKSPACE_STOPPED event");
+        dispatcher = dispatchers.get(getUserId());
+
+        dispatcher.sendTrackEvent(WORKSPACE_STOPPED, commonProperties, dispatcher.getLastIp(), dispatcher.getLastUserAgent(), dispatcher.getLastResolution());
       } catch (ExecutionException e) {
       }
     }
@@ -539,7 +391,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
       analytics.flush();
       try {
         Thread.sleep(500);
-      } catch(InterruptedException e) {
+      } catch (InterruptedException e) {
         LOG.warn("Thread.sleep() interrupted", e);
       }
       analytics.shutdown();
@@ -554,10 +406,7 @@ public class AnalyticsManager extends AbstractAnalyticsManager {
  */
 class AnalyticsProvider {
   public Analytics getAnalytics(String segmentWriteKey, ExecutorService networkExecutor) {
-    return Analytics.builder(segmentWriteKey)
-        .networkExecutor(networkExecutor)
-        .flushQueueSize(1)
-        .build();
+    return Analytics.builder(segmentWriteKey).networkExecutor(networkExecutor).flushQueueSize(1).build();
   }
 }
 


### PR DESCRIPTION
- Formatting was not default formatting, and broke Che/IntelliJ.  Reformatted `AnalyticsManager`
- Pull out common property construction
- Do not generate a new set of properties, use the ones constructed in the `AbstractAnalyticsManager`